### PR TITLE
fix: Add configuration_json to ChromaDB embedded server responses

### DIFF
--- a/backend/CHROMADB_LOCAL_VS_PRODUCTION.md
+++ b/backend/CHROMADB_LOCAL_VS_PRODUCTION.md
@@ -88,3 +88,24 @@ curl http://localhost:8000/api/v1/heartbeat
 
 Sau khi deploy, production sẽ hoạt động giống local! 🎉
 
+## 🔬 Debug Tool
+
+Để so sánh response format giữa local và production:
+
+```bash
+# Test local ChromaDB server (chính thức)
+node backend/scripts/test-chromadb-response.js --local
+
+# Test embedded server (custom Python)
+node backend/scripts/test-chromadb-response.js --embedded
+
+# Test cả hai để so sánh
+node backend/scripts/test-chromadb-response.js --local --embedded
+```
+
+Tool này sẽ:
+- Test heartbeat endpoint
+- Test `getOrCreateCollection()` qua ChromaDB client
+- Test raw HTTP response để xem format thực tế
+- So sánh `embedding_function` field giữa 2 servers
+

--- a/backend/python/chromadb_embedded_server.py
+++ b/backend/python/chromadb_embedded_server.py
@@ -119,22 +119,29 @@ class ChromaDBHandler(BaseHTTPRequestHandler):
                 self.send_header('Access-Control-Allow-Origin', '*')
                 self.end_headers()
                 # Get embedding_function if available
-                # Return empty dict {} instead of None - ChromaDB client may expect an object
                 embedding_func = {}
                 try:
                     if hasattr(collection, 'embedding_function') and collection.embedding_function is not None:
                         embedding_func = collection.embedding_function
                 except:
                     pass
-                # If embedding_func is None, use empty dict
                 if embedding_func is None:
                     embedding_func = {}
-                    
+                
+                # Match ChromaDB official server format
                 response = {
                     'name': collection.name,
                     'metadata': collection.metadata or {},
                     'id': str(collection.id),
-                    'embedding_function': embedding_func  # ChromaDB client expects this field
+                    'configuration_json': {
+                        'embedding_function': {
+                            'type': 'unknown' if embedding_func == {} else 'known',
+                            'name': 'default' if embedding_func != {} else None,
+                            'config': embedding_func if embedding_func != {} else {}
+                        }
+                    },
+                    # Top-level embedding_function for backward compatibility
+                    'embedding_function': embedding_func
                 }
                 logger.info(f"GET v1 Collection response: name={response['name']}, id={response['id']}, has_embedding_func={embedding_func is not None}")
                 self.wfile.write(json.dumps(response).encode())
@@ -165,25 +172,31 @@ class ChromaDBHandler(BaseHTTPRequestHandler):
                 self.send_header('Access-Control-Allow-Origin', '*')
                 self.end_headers()
                 # Get embedding_function if available
-                # Return empty dict {} instead of None - ChromaDB client may expect an object
                 embedding_func = {}
                 try:
                     if hasattr(collection, 'embedding_function') and collection.embedding_function is not None:
                         embedding_func = collection.embedding_function
                 except:
                     pass
-                # If embedding_func is None, use empty dict
                 if embedding_func is None:
                     embedding_func = {}
-                    
-                # Return v2 format
+                
+                # Match ChromaDB official server format
                 response = {
                     'id': str(collection.id),
                     'name': collection.name,
                     'metadata': collection.metadata or {},
                     'tenant': 'default_tenant',
                     'database': 'default_database',
-                    'embedding_function': embedding_func  # ChromaDB client expects this field
+                    'configuration_json': {
+                        'embedding_function': {
+                            'type': 'unknown' if embedding_func == {} else 'known',
+                            'name': 'default' if embedding_func != {} else None,
+                            'config': embedding_func if embedding_func != {} else {}
+                        }
+                    },
+                    # Top-level embedding_function for backward compatibility
+                    'embedding_function': embedding_func
                 }
                 logger.info(f"GET v2 Collection response: name={response['name']}, id={response['id']}, has_embedding_func={embedding_func is not None}")
                 self.wfile.write(json.dumps(response).encode())
@@ -239,15 +252,26 @@ class ChromaDBHandler(BaseHTTPRequestHandler):
                     pass
                 
                 # Return format matching ChromaDB server response
-                # ChromaDB client expects embedding_function to be present
-                # Try returning empty dict {} instead of None - some client versions may expect an object
-                # If embedding_func is None, return empty dict to match ChromaDB server format
+                # ChromaDB server returns configuration_json with embedding_function inside
+                # Not at top level! Match the official server format
+                # Top-level embedding_function is not required, but we include it for compatibility
                 embedding_function_value = embedding_func if embedding_func is not None else {}
                 
+                # Match ChromaDB official server format
+                # Official server has: configuration_json.embedding_function, not top-level
                 result = {
                     'name': collection.name,
                     'metadata': collection.metadata or {},
                     'id': str(collection.id),
+                    # Include configuration_json to match official server format
+                    'configuration_json': {
+                        'embedding_function': {
+                            'type': 'unknown' if embedding_function_value == {} else 'known',
+                            'name': 'default' if embedding_function_value != {} else None,
+                            'config': embedding_function_value if embedding_function_value != {} else {}
+                        }
+                    },
+                    # Top-level embedding_function for backward compatibility (can be omitted)
                     'embedding_function': embedding_function_value
                 }
                 
@@ -303,10 +327,8 @@ class ChromaDBHandler(BaseHTTPRequestHandler):
                 self.send_header('Access-Control-Allow-Origin', '*')
                 self.end_headers()
                 # ChromaDB v2 returns collection in a specific format
-                # ChromaDB client expects embedding_function to be present
-                # Try returning empty dict {} instead of None - some client versions may expect an object
-                embedding_func = result.get('embedding_function')
-                # If embedding_func is None or empty, return empty dict to match ChromaDB server format
+                # Match official server format: configuration_json.embedding_function, not top-level
+                embedding_func = result.get('embedding_function', {})
                 embedding_function_value = embedding_func if embedding_func and embedding_func != {} else {}
                 
                 response = {
@@ -315,6 +337,15 @@ class ChromaDBHandler(BaseHTTPRequestHandler):
                     'metadata': result['metadata'],
                     'tenant': 'default_tenant',
                     'database': 'default_database',
+                    # Include configuration_json to match official server format
+                    'configuration_json': result.get('configuration_json', {
+                        'embedding_function': {
+                            'type': 'unknown',
+                            'name': None,
+                            'config': {}
+                        }
+                    }),
+                    # Top-level embedding_function for backward compatibility (optional)
                     'embedding_function': embedding_function_value
                 }
                 # Log full response for debugging (but truncate if too long)

--- a/backend/scripts/test-chromadb-response.js
+++ b/backend/scripts/test-chromadb-response.js
@@ -1,0 +1,200 @@
+/**
+ * Script để test và so sánh response format giữa ChromaDB server chính thức và embedded server
+ * Giúp debug tại sao local chạy được mà production lại lỗi
+ */
+
+const { ChromaClient } = require('chromadb');
+const http = require('http');
+
+async function testChromaDBResponse(url, name) {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`Testing: ${name}`);
+  console.log(`URL: ${url}`);
+  console.log('='.repeat(60));
+
+  try {
+    const client = new ChromaClient({ path: url });
+    
+    // Test heartbeat first
+    console.log('\n1. Testing heartbeat...');
+    try {
+      // Try v2 first (newer API)
+      let heartbeat;
+      try {
+        heartbeat = await fetch(`${url}/api/v2/heartbeat`);
+      } catch (e) {
+        heartbeat = await fetch(`${url}/api/v1/heartbeat`);
+      }
+      
+      if (heartbeat.ok) {
+        const heartbeatData = await heartbeat.json();
+        console.log('✅ Heartbeat OK:', heartbeatData);
+      } else {
+        const text = await heartbeat.text();
+        console.log('⚠️  Heartbeat response:', heartbeat.status, text);
+      }
+    } catch (err) {
+      console.log('❌ Heartbeat failed:', err.message);
+      console.log('   Server might not be running. Continuing anyway...');
+      // Don't return, continue to test collection
+    }
+
+    // Test getOrCreateCollection
+    console.log('\n2. Testing getOrCreateCollection...');
+    const collectionName = 'test-collection-response';
+    
+    try {
+      const collection = await client.getOrCreateCollection({
+        name: collectionName,
+        metadata: { test: true },
+      });
+
+      console.log('✅ Collection created/retrieved');
+      console.log('Collection object type:', typeof collection);
+      console.log('Collection object keys:', Object.keys(collection || {}));
+      
+      // Check properties
+      console.log('\nCollection properties:');
+      console.log('  - name:', collection?.name);
+      console.log('  - id:', collection?.id);
+      console.log('  - metadata:', collection?.metadata);
+      
+      // Safely check embedding_function
+      try {
+        const ef = collection?.embedding_function;
+        console.log('  - embedding_function:', ef === null ? 'null' : ef === undefined ? 'undefined' : typeof ef);
+        if (ef && typeof ef === 'object') {
+          console.log('  - embedding_function keys:', Object.keys(ef));
+        }
+      } catch (efError) {
+        console.log('  - embedding_function: ERROR accessing -', efError.message);
+      }
+
+      // Check if collection has methods
+      console.log('\nCollection methods:');
+      console.log('  - query:', typeof collection?.query);
+      console.log('  - add:', typeof collection?.add);
+      console.log('  - upsert:', typeof collection?.upsert);
+      console.log('  - delete:', typeof collection?.delete);
+
+      // Try to make a raw HTTP request to see actual response (GET existing collection)
+      console.log('\n3. Testing raw HTTP GET response (existing collection)...');
+      await testRawHTTPGetResponse(url, collectionName);
+
+    } catch (error) {
+      console.log('❌ Error:', error.message);
+      console.log('Stack:', error.stack);
+    }
+
+  } catch (error) {
+    console.log('❌ Failed to connect:', error.message);
+  }
+}
+
+async function testRawHTTPGetResponse(baseUrl, collectionName) {
+  return new Promise((resolve, reject) => {
+    // Test GET collection (when it already exists)
+    const url = new URL(`${baseUrl}/api/v2/tenants/default_tenant/databases/default_database/collections/${collectionName}`);
+    
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (url.protocol === 'https:' ? 443 : 80),
+      path: url.pathname,
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    const req = http.request(options, (res) => {
+      let data = '';
+      
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      
+      res.on('end', () => {
+        console.log('Raw HTTP GET Response:');
+        console.log('  Status:', res.statusCode);
+        console.log('  Headers:', JSON.stringify(res.headers, null, 2));
+        try {
+          const json = JSON.parse(data);
+          console.log('  Body (formatted):');
+          console.log(JSON.stringify(json, null, 2));
+          
+          // Check embedding_function in raw response
+          if (json.embedding_function !== undefined) {
+            console.log('\n  ✅ embedding_function present in response');
+            console.log('     Type:', typeof json.embedding_function);
+            console.log('     Value:', json.embedding_function);
+            if (json.embedding_function === null) {
+              console.log('     ⚠️  Value is null (might cause issues)');
+            } else if (typeof json.embedding_function === 'object' && Object.keys(json.embedding_function).length === 0) {
+              console.log('     ✅ Value is empty object {} (should work)');
+            }
+          } else {
+            console.log('\n  ❌ embedding_function MISSING in response');
+            console.log('     This is likely the cause of the error!');
+          }
+        } catch (e) {
+          console.log('  Body (raw):', data);
+          console.log('  Parse error:', e.message);
+        }
+        resolve();
+      });
+    });
+
+    req.on('error', (error) => {
+      console.log('❌ HTTP GET request error:', error.message);
+      console.log('   This might mean the server is not running or endpoint not supported');
+      resolve(); // Don't reject, just continue
+    });
+
+    req.setTimeout(5000, () => {
+      console.log('❌ Request timeout');
+      req.destroy();
+      resolve();
+    });
+
+    req.end();
+  });
+}
+
+async function main() {
+  console.log('🔍 ChromaDB Response Format Comparison Tool');
+  console.log('This tool helps debug why local works but production fails\n');
+
+  // Test local ChromaDB (if running)
+  if (process.argv.includes('--local')) {
+    await testChromaDBResponse('http://localhost:8000', 'Local ChromaDB (Official Server)');
+  }
+
+  // Test embedded server (if running)
+  if (process.argv.includes('--embedded')) {
+    await testChromaDBResponse('http://localhost:8001', 'Embedded Server (Custom Python)');
+  }
+
+  // If no args, test both
+  if (!process.argv.includes('--local') && !process.argv.includes('--embedded')) {
+    console.log('Usage:');
+    console.log('  node test-chromadb-response.js --local      # Test local ChromaDB server');
+    console.log('  node test-chromadb-response.js --embedded   # Test embedded server');
+    console.log('  node test-chromadb-response.js --local --embedded  # Test both\n');
+    
+    // Try both by default
+    try {
+      await testChromaDBResponse('http://localhost:8000', 'Local ChromaDB (Official Server)');
+    } catch (e) {
+      console.log('Local ChromaDB not available');
+    }
+    
+    try {
+      await testChromaDBResponse('http://localhost:8001', 'Embedded Server (Custom Python)');
+    } catch (e) {
+      console.log('Embedded server not available');
+    }
+  }
+}
+
+main().catch(console.error);
+


### PR DESCRIPTION
- Add configuration_json.embedding_function to match official ChromaDB server format
- Keep top-level embedding_function for backward compatibility
- Fix 'Cannot read properties of undefined (reading embedding_function)' error
- Improve error handling and logging in vectorStore.js
- Add test script to compare response formats between local and production
- Fix PowerShell script encoding issues

This fixes the issue where local works but production fails because:
- Local uses official ChromaDB server with configuration_json
- Production uses custom embedded server that was missing this field
- ChromaDB client expects configuration_json.embedding_function structure